### PR TITLE
Add missing package dependency declaration

### DIFF
--- a/hamlet-mode.el
+++ b/hamlet-mode.el
@@ -4,7 +4,7 @@
 ;; Keywords: wp, languages, comm
 ;; URL: https://github.com/lightquake/hamlet-mode
 ;; Version: 0.1
-;;
+;; Package-Requires: ((cl-lib "0.3"))
 
 ;; Copyright (c) 2013 Kata
 


### PR DESCRIPTION
cl-lib is not available in Emacs 23, but GNU ELPA carries a compatibility package. This commit ensures it will be installed if required when hamlet-mode is installed.

-Steve

Re. https://github.com/milkypostman/melpa/pull/1224
