### PR TITLE
regex option to highlight classes and id's when they start at the beginning of tag

### DIFF
--- a/hamlet-mode.el
+++ b/hamlet-mode.el
@@ -136,7 +136,7 @@ no previous nonblank line, the only valid indentation is 0."
 
     ;; Attributes can be either name=val, #id, or .class.
     (,(concat "\\(?:^\\|[ \t]\\)\\(?:\\("
-              hamlet//name-regexp "\\)=\\([^@^ \r\n]*\\)\\|\\([.#]"
+              hamlet//name-regexp "\\)=\\([^@^ \r\n]*\\)\\|<?\\([.#]"
               hamlet//name-regexp "\\)\\)")
      (1 font-lock-variable-name-face nil t) ; Attribute names
      (2 font-lock-string-face nil t) ; Attribute values


### PR DESCRIPTION
Hello, thanks for hamlet mode. I've been using it quite frequently.

In hamlet, writing the 'div' tag name is optional. So `<div .class>` and `<.class>` are the same thing. Currently hamlet-mode doesn't highlight classes and id's when they start at the beginning of a tag. I added an optional match for the `<` character before `[.#]` in the regexp so it will catch and highlight these cases.

I tested this on several of my hamlet files, but let me know if you think there's a better way to do it!
